### PR TITLE
fix: compile node fail for declarations error

### DIFF
--- a/configs/webpack.node.config.js
+++ b/configs/webpack.node.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
-const tsConfigPath = path.join(__dirname, '..', '/tsconfig.json');
+const tsConfigPath = path.join(__dirname, '..', 'tsconfig.json');
 const srcDir = path.join(__dirname, '..', 'src', 'node');
 const distDir = path.join(__dirname, '..', 'dist-node', 'server');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,5 +29,8 @@
     "typeRoots": [
       "./node_modules/@types"
     ]
-  }
+  },
+  "exclude": [
+    "extensions"
+  ]
 }


### PR DESCRIPTION
<img width="901" alt="image" src="https://user-images.githubusercontent.com/2226423/179136737-0aa84e70-46c7-4988-8b9e-21cba7806d64.png">
修复插件目录被 ts-loader 扫描到，导致 compile:node 失败