### PR TITLE
fix:  https访问时，浏览器要求使用wss协议

### DIFF
--- a/src/browser/render-app.ts
+++ b/src/browser/render-app.ts
@@ -12,14 +12,14 @@ export async function renderApp(opts: IClientAppOpts) {
   const hostname = window.location.hostname;
   const query = new URLSearchParams(window.location.search);
   // 线上的静态服务和 IDE 后端是一个 Server
-  const serverPort = process.env.DEVELOPMENT ? 8000: window.location.port;
-  const staticServerPort = process.env.DEVELOPMENT ? 8080: window.location.port;
+  const serverPort = process.env.DEVELOPMENT ? 8000 : window.location.port;
+  const staticServerPort = process.env.DEVELOPMENT ? 8080 : window.location.port;
   const webviewEndpointPort = process.env.DEVELOPMENT ? 8899 : 8000;
   opts.workspaceDir = opts.workspaceDir || query.get('workspaceDir') || process.env.WORKSPACE_DIR;
 
   opts.extensionDir = opts.extensionDir || process.env.EXTENSION_DIR;
   opts.injector = injector;
-  opts.wsPath =  process.env.WS_PATH || `ws://${hostname}:${serverPort}`;
+  opts.wsPath = process.env.WS_PATH || window.location.protocol == 'https:' ? `wss://${hostname}:${serverPort}` : `ws://${hostname}:${serverPort}`;
   opts.extWorkerHost = opts.extWorkerHost || process.env.EXTENSION_WORKER_HOST || `http://${hostname}:${staticServerPort}/worker-host.js`;
   opts.staticServicePath = `http://${hostname}:${serverPort}`;
   const anotherHostName = process.env.WEBVIEW_HOST || hostname;


### PR DESCRIPTION
https访问时，浏览器 console 出现错误信息如下，不能建立 websocket 连接

bundle.js:2 Mixed Content: The page at 'https://xxx/' was loaded over HTTPS, but attempted to connect to the insecure WebSocket endpoint 'ws://xxx/service'. This request has been blocked; this endpoint must be available over WSS.

