### PR TITLE
fix: get webview endpoint port from host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ ENV EXTENSION_DIR extensions
 
 COPY . .
 
-ENV ELECTRON_MIRROR http://npm.taobao.org/mirrors/electron/
+ENV ELECTRON_MIRROR https://npmmirror.com/mirrors/electron/
 
 RUN mkdir -p ${WORKSPACE_DIR}  &&\
     mkdir -p ${EXTENSION_DIR}
 
-RUN yarn --ignore-scripts --network-timeout 1000000&& \
+RUN yarn --ignore-scripts --network-timeout 1000000 && \
     yarn run build && \
     yarn run download:extensions && \
     rm -rf ./node_modules

--- a/src/browser/render-app.ts
+++ b/src/browser/render-app.ts
@@ -16,7 +16,7 @@ export async function renderApp(opts: IClientAppOpts) {
   // 线上的静态服务和 IDE 后端是一个 Server
   const serverPort = process.env.DEVELOPMENT ? 8000 : window.location.port;
   const staticServerPort = process.env.DEVELOPMENT ? 8080 : window.location.port;
-  const webviewEndpointPort = process.env.DEVELOPMENT ? 8899 : 8000;
+  const webviewEndpointPort = process.env.DEVELOPMENT ? 8899 : window.location.port;
   opts.workspaceDir = opts.workspaceDir || query.get('workspaceDir') || process.env.WORKSPACE_DIR;
 
   opts.extensionDir = opts.extensionDir || process.env.EXTENSION_DIR;

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,6 +1,6 @@
 import { startServer } from './start-server';
 import { ExpressFileServerModule } from '@opensumi/ide-express-file-server/lib/node';
-import { CommonNodeModules } from '../../src/node/common-modules';
+import { CommonNodeModules } from './common-modules';
 
 startServer({
   modules: [

--- a/src/node/start-server.ts
+++ b/src/node/start-server.ts
@@ -5,8 +5,7 @@ import * as koaStatic from 'koa-static';
 import { Deferred } from '@opensumi/ide-core-common';
 import { IServerAppOpts, ServerApp, NodeModule } from '@opensumi/ide-core-node';
 
-// export const DEFAULT_OPENVSX_REGISTRY = 'https://marketplace.smartide.cn'; // China Mirror
-export const DEFAULT_OPENVSX_REGISTRY = 'https://open-vsx.org'; // Official Registry
+export const DEFAULT_OPENVSX_REGISTRY = 'https://open-vsx.org';
 
 export async function startServer(arg1: NodeModule[] | Partial<IServerAppOpts>) {
   const app = new Koa();


### PR DESCRIPTION
Changes:

- Change WebviewEndpointPort to `window.location.port` to adapt the Docker port proxy.